### PR TITLE
add github action

### DIFF
--- a/.github/workflows/test_cylc.yml
+++ b/.github/workflows/test_cylc.yml
@@ -1,0 +1,60 @@
+name: test
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '17 22 * * 6'  # Every Saturday at 22:17
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest']
+        micromamba_installed: [true, false]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Mamba
+        if: ${{ matrix.micromamba_installed }} == true
+        uses: mamba-org/setup-micromamba@v1
+
+      - name: Setup Cylc
+        uses: ./
+        with:
+          cylc_rose: true
+
+      - name: Version
+        run: |
+          cylc version
+
+      - name: Validate
+        run: |
+          # this should pass
+          cylc validate ./example;
+          # this should fail
+          ! cylc validate ./example -s ANSWER=6;
+
+      - name: Lint
+        run: |
+          # this should fail
+          ! cylc lint ./example > out;
+          grep 'S004' out;
+          grep 'found 1 issue' out;
+
+      - name: Rose Macro
+        run: |
+          # this should fail
+          ! rose macro -V -C ./example 2> err;
+          grep 'issues: 1' err
+          grep 'Not an integer' err
+
+      - name: Rose Metadata Check
+        run: |
+          rose metadata-check -C ./example/meta

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,4 @@
+# FORMAT: <proper-name>  <proper-email>  <commit-name>  <commit-email>
+# Omit commit-name or commit-email if same as proper
+
+Oliver Sanders             <oliver.sanders@metoffice.gov.uk>    Oliver sanders

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Cylc: How to Contribute
+
+Thanks for you interest in the Cylc project!
+
+Contributions are welcome, please open an issue to discuss changes before
+raising a pull request.
+
+You can also get in touch via:
+
+* The developers chat: [![chat](https://img.shields.io/matrix/cylc-general:matrix.org)](https://matrix.to/#/#cylc-general:matrix.org)
+* The forum: [![forum](https://img.shields.io/discourse/https/cylc.discourse.group/posts.svg)](https://cylc.discourse.group/)
+
+
+## New Contributors
+
+Please read the [CLA](#contributor-licence-agreement-and-certificate-of-origin).
+
+Please add your name to the
+[Code Contributors](#code-contributors) section of this file as part of your
+first Pull Request (for each Cylc repository you contribute to).
+
+
+## Code Contributors
+
+The following people have contributed to this code under the terms of
+the Contributor Licence Agreement and Certificate of Origin detailed
+below:
+
+<!-- start-shortlog -->
+ - Oliver Sanders
+<!-- end-shortlog -->
+
+(All contributors are identifiable with email addresses in the git version
+control logs or otherwise.)
+
+
+## Contributor Licence Agreement and Certificate of Origin
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have
+    the right to submit it, either on my behalf or on behalf of my
+    employer, under the terms and conditions as described by this file;
+    or
+
+(b) The contribution is based upon previous work that, to the best of
+    my knowledge, is covered under an appropriate licence and I have
+    the right or permission from the copyright owner under that licence
+    to submit that work with modifications, whether created in whole or
+    in part by me, under the terms and conditions as described by
+    this file; or
+
+(c) The contribution was provided directly to me by some other person
+    who certified (a) or (b) and I have not modified it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including my
+    name and email address) is retained for the full term of
+    the copyright and may be redistributed consistent with this project
+    or the licence(s) involved.
+
+(e) I, or my employer, grant to NIWA and all recipients of
+    this software a perpetual, worldwide, non-exclusive, no-charge,
+    royalty-free, irrevocable copyright licence to reproduce, modify,
+    prepare derivative works of, publicly display, publicly perform,
+    sub-licence, and distribute this contribution and such modifications
+    and derivative works consistent with this project or the licence(s)
+    involved or other appropriate open source licence(s) specified by
+    the project and approved by the
+    [Open Source Initiative (OSI)](http://www.opensource.org/).
+
+(f) If I become aware of anything that would make any of the above
+    inaccurate, in any way, I will let NIWA know as soon as
+    I become aware.
+
+(The Cylc Contributor Licence Agreement and Certificate of Origin is
+inspired that of [Rose](https://github.com/metomi/rose), which in turn was
+inspired by the Certificate of Origin used by Enyo and the Linux Kernel.)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, The Cylc Workflow Engine
+Copyright (c) NIWA & British Crown (Met Office) & Contributors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,62 @@
+# Setup Cylc Action
+
+A GitHub action to install Cylc (and optionally Rose).
+
+This action uses micromamba to install Cylc (and optionally Rose) into an
+environment called `cylc`. It puts the `cylc`, `isodatetime` (and optionally
+`rose`) commands in `$PATH` so they can be called by later steps in your
+workflow.
+
+This action runs on the Linux and Mac OS runners (but not Windows).
+
+
+## Example Workflow
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Cylc
+        uses: cylc/setup-cylc@v1
+        with:
+          cylc_rose: true
+
+      - name: Run Cylc Tests
+        run: |
+          cylc validate ./my-workflow
+          cylc lint ./my-workflow
+
+      - name: Run Rose Tests
+        run: |
+          rose macro -V -C ./my-workflow
+          rose metadata-check -C ./my-workflow/meta
+          rose metadata-check -C ./my-workflow/app/my-app/meta
+```
+
+
+## Options
+
+**``cylc_version``** [default 8]
+
+The version of Cylc to install e.g:
+
+```
+# install the latest version of Cylc 8
+cylc_version: 8
+
+# install the latest version of Cylc 8.1
+cylc_version: 8.1
+
+# install Cylc 8.1.1
+cylc_version: 8.1.1
+```
+
+
+**``cylc_rose``** [default false]
+
+Install Rose along with Cylc Rose support.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,84 @@
+name: Setup Cylc
+description: Install Cylc.
+
+inputs:
+  cylc_version:
+    description: 'The Cylc version to install (or an abbreviation e.g. 8 to pick up the latest version).'
+    default: '8'
+  cylc_rose:
+    description: 'Install cylc-rose?'
+    default: false
+
+runs:
+  using: composite
+  steps:
+    # check if micromamba is already installed
+    - name: Check Mamba
+      id: check_mamba
+      continue-on-error: true
+      shell: bash
+      run: micromamba --version
+
+    # install micromamba if necessary
+    - name: Install Mamba
+      if: steps.check_mamba.outcome == 'failure'
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        init-shell: bash
+        post-cleanup: 'all'
+
+    # install cylc (and cylc-rose if requested) into a mamba environment
+    - name: Install Cylc
+      shell: bash
+      run: |
+        # write env file
+        cat > cylc_env.yml <<__ENV__
+        name: cylc
+        channels:
+          - conda-forge
+        dependencies:
+          - cylc-flow-base=${{ inputs.cylc_version }}
+        __ENV__
+
+        # install cylc-rose?
+        if ${{ inputs.cylc_rose }}; then
+          echo '  - cylc-rose' >> cylc_env.yml
+        fi
+
+        # create environment
+        micromamba env create -y --file=cylc_env.yml
+        rm cylc_env.yml
+
+    # create required wrapper scripts
+    - name: Install Wrapper
+      shell: bash -el {0}
+      run: |
+        # create a temp dir for wrapper scripts
+        cd $(mktemp -d)
+
+        # determine which wrappers to create
+        micromamba activate cylc
+        wrappers=(cylc isodatetime)
+        if ${{ inputs.cylc_rose }}; then
+          wrappers+=(rose)
+        fi
+
+        # create a wrapper for each command in the temp dir
+        for wrapper in "${wrappers[@]}"; do
+          EXE="$(command -v "$wrapper")"
+          cat > "$wrapper" <<__WRAPPER__
+        #!/usr/bin/env bash
+        exec "${EXE}" "\$@"
+        __WRAPPER__
+
+          chmod +x "$wrapper"
+        done
+
+        # add the temp dir to $PATH for future steps
+        echo "$PWD" >> $GITHUB_PATH
+
+    # check the install worked
+    - name: Test
+      shell: bash
+      run: |
+        cylc version

--- a/example/flow.cylc
+++ b/example/flow.cylc
@@ -1,0 +1,13 @@
+#!jinja2
+
+{% set ANSWER = ANSWER | default(42) %}
+{{ assert(ANSWER == 42, 'The constants are changing') }}
+
+[scheduling]
+    [[graph]]
+        R1 = """
+            foo
+        """
+
+[runtime]
+  [[foo]]  # indentation is off here

--- a/example/meta/rose-meta.conf
+++ b/example/meta/rose-meta.conf
@@ -1,0 +1,2 @@
+[template variables=QUESTION]
+type=integer

--- a/example/rose-suite.conf
+++ b/example/rose-suite.conf
@@ -1,0 +1,2 @@
+[template variables]
+QUESTION='What do you get if you multiply 6 by 7?'


### PR DESCRIPTION
September training day activity: TIL reusable actions.

Add a simple "setup-cylc" action to facilitate writing CI for Cylc workflow projects.

Namely:

```
cylc lint
cylc validate
rose macro -V
rose metadata-check
```

The test action on this PR won't run until merged. Example of successful run [here](https://github.com/oliver-sanders/setup-cylc/actions/runs/10740164846)

Example of intended usage (using oliver-sanders/setup-cylc) on a dummy workflow, [here](https://github.com/oliver-sanders/temp-example-cylc-workflows/actions/runs/10740321725/job/29788123789).

TODO:
* [ ] Tag / branch V1 post-merge
* [ ] Setup caching (future work - https://github.com/cylc/setup-cylc/issues/2)

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included  - initial commit!
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.