### PR TITLE
Mac OS: Patch GH runners

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -82,3 +82,13 @@ runs:
       shell: bash
       run: |
         cylc version
+
+    - name: Patch DNS (Mac OS)
+      shell: bash
+      if: startsWith(runner.os, 'macos')
+      run: |
+        # NOTE: This is cloned from cylc/release-actions
+        # We don't pull this action in from that repo as that would create an
+        # additional dependency which would need to be whitelisted by GH orgs.
+        echo -e "$(ipconfig getifaddr en0) $(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+        dscacheutil -q host -a name $(hostname -f)


### PR DESCRIPTION
DNS has been flaky for Mac OS runners for a long time and it doesn't look like they are going to fix it.

Unfortunately, this will lead to `cylc validate` failures in situations where cylc-rose is installed (and a `rose-suite.conf` file is present), presumably due to the `ROSE_ORIG_HOST` variable.

This ports the cylc/release-actions patch, partly to fix our internal tests, but mostly to prevent our downstream users from discovering this issue!